### PR TITLE
Update copyCertificate function to preserve file metadata

### DIFF
--- a/certificate.cpp
+++ b/certificate.cpp
@@ -116,31 +116,24 @@ void Certificate::copyCertificate(const std::string& certSrcFilePath,
                                   const std::string& certFilePath)
 {
     // Copy the certificate to the installation path
-    // During boot up will be parsing existing file so no need to
+    // During bootup will be parsing existing file so no need to
     // copy it.
     if (certSrcFilePath != certFilePath)
     {
-        std::ifstream inputCertFileStream;
-        std::ofstream outputCertFileStream;
-        inputCertFileStream.exceptions(
-            std::ifstream::failbit | std::ifstream::badbit |
-            std::ifstream::eofbit);
-        outputCertFileStream.exceptions(
-            std::ofstream::failbit | std::ofstream::badbit |
-            std::ofstream::eofbit);
-        try
-        {
-            inputCertFileStream.open(certSrcFilePath);
-            outputCertFileStream.open(certFilePath, std::ios::out);
-            outputCertFileStream << inputCertFileStream.rdbuf() << std::flush;
-            inputCertFileStream.close();
-            outputCertFileStream.close();
-        }
-        catch (const std::exception& e)
+        // -p flag preserves the file metadata when copying 
+        // -f flag forces the copy
+        char command[] =
+            std::format("cp -fp {} {}", certSrcFilePath, certFilePath);
+        int status_code = std::system(command);
+
+        // Non-zero `status_code` indicates something went wrong with issuing
+        // the copy command.
+        if (status_code != 0)
         {
             lg2::error(
                 "Failed to copy certificate, ERR:{ERR}, SRC:{SRC}, DST:{DST}",
-                "ERR", e, "SRC", certSrcFilePath, "DST", certFilePath);
+                "ERR", status_code, "SRC", certSrcFilePath, "DST",
+                certFilePath);
             elog<InternalFailure>();
         }
     }


### PR DESCRIPTION
Cert Manager currently creates a new file with the same content during Certificate::copyCertificate function but doesn’t preserve the file metadata(uid,gid,rwx etc.) from the original file. It's a nice to have feature if both content and file metadata are preserved during the copy. This would be useful for security software running later on to validate the file's integrity and authenticity.

This is achievable by utilizing the `cp` command. PCM will issue a std::system call to ask the underlying host environment's command processor to execute the `cp -fp` call.

This PR doesn't change any current business logic to any existing code that depends on PCM.
